### PR TITLE
Fix promise dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,14 +46,14 @@
     "graceful-fs": "^3.0.6",
     "junk": "^1.0.1",
     "minimatch": "^2.0.7",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "promise": "^7.0.1"
   },
   "devDependencies": {
     "chai": "^2.3.0",
     "chai-as-promised": "^5.0.0",
     "eslint": "^0.21.2",
     "mocha": "^2.2.5",
-    "promise": "^7.0.1",
     "read-dir-files": "^0.1.1",
     "rewire": "^2.3.3",
     "through2": "^0.6.5"


### PR DESCRIPTION
I ran into a problem running recursive-copy:

    Error: Cannot find module 'promise'

I checked and found the dependency on promise is incorrectly listed as a devDependency. This is a simple move to fix that.