### PR TITLE
Apply filters before traversing

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -68,19 +68,6 @@ module.exports = function(src, dest, options, callback) {
 					}
 				});
 		})
-		.then(function(filePaths) {
-			var relativePaths = filePaths.map(function(filePath) {
-				return path.relative(src, filePath);
-			});
-			var filteredPaths = getFilteredPaths(relativePaths, options.filter, {
-				dot: options.dot,
-				junk: options.junk
-			});
-			var absolutePaths = filteredPaths.map(function(relativePath) {
-				return path.join(src, relativePath);
-			});
-			return absolutePaths;
-		})
 		.then(function(filteredPaths) {
 			return copyFileset(filteredPaths, src, dest, options)
 		})
@@ -142,17 +129,22 @@ module.exports = function(src, dest, options, callback) {
 				return Promise.all(
 					filenames.map(function(filename) {
 						var filePath = path.join(srcPath, filename);
-						return srcStat(filePath)
-							.then(function(stats) {
-								if (stats.isDirectory()) {
-									return getFileListing(filePath)
-										.then(function(childPaths) {
-											return [filePath].concat(childPaths);
-										});
-								} else {
-									return [filePath];
-								}
-							});
+						var relativePath = path.relative(src, filePath);
+						if (filterPath(relativePath, options.filter, { dot: options.dot, junk: options.junk })) {
+							return srcStat(filePath)
+								.then(function(stats) {
+									if (stats.isDirectory()) {
+										return getFileListing(filePath)
+											.then(function(childPaths) {
+												return [filePath].concat(childPaths);
+											});
+									} else {
+										return [filePath];
+									}
+								});
+						} else {
+							return Promise.resolve([]);
+						}
 					})
 				)
 				.then(function mergeArrays(arrays) {
@@ -161,13 +153,11 @@ module.exports = function(src, dest, options, callback) {
 			});
 	}
 
-	function getFilteredPaths(paths, filter, options) {
+	function filterPath(filePath, filter, options) {
 		var useDotFilter = !options.dot;
 		var useJunkFilter = !options.junk;
-		if (!filter && !useDotFilter && !useJunkFilter) { return paths; }
-		return paths.filter(function(path) {
-			return (!useDotFilter || dotFilter(path)) && (!useJunkFilter || junkFilter(path)) && (!filter || (maximatch(slash(path), filter, options).length > 0));
-		});
+		if (!filter && !useDotFilter && !useJunkFilter) { return true; }
+		return (!useDotFilter || dotFilter(filePath)) && (!useJunkFilter || junkFilter(filePath)) && (!filter || (maximatch(slash(filePath), filter, options).length > 0));
 
 
 		function dotFilter(relativePath) {


### PR DESCRIPTION
The original implementation apply filters after recursively traversing all files and directories.

In some cases, huge directories are entirely filtered out by a user-supplied filter. Such directories do not need to be traversed at all.

Therefore, applying filters before traversing can save a lot of time and memory.