### PR TITLE
chore: reduce dependencies by replacing del with rimraf

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -7,7 +7,7 @@ var path = require('path');
 var EventEmitter = require('events').EventEmitter;
 var pify = require('pify');
 var mkdirp = require('mkdirp');
-var del = require('del');
+var rimraf = require('rimraf');
 var junk = require('junk');
 var errno = require('errno');
 var maximatch = require('maximatch');
@@ -33,6 +33,7 @@ var lstat = pify(fs.lstat, Promise);
 var readlink = pify(fs.readlink, Promise);
 var symlink = pify(fs.symlink, Promise);
 var readdir = pify(fs.readdir, Promise);
+var remove = pify(rimraf, Promise);
 
 module.exports = function(src, dest, options, callback) {
 	if ((arguments.length === 3) && (typeof options === 'function')) {
@@ -259,7 +260,7 @@ function ensureDestinationIsWritable(destPath, srcStats, shouldOverwriteExisting
 			if (isMergePossible) { return true; }
 
 			if (shouldOverwriteExistingFiles) {
-				return del(destPath, { force: true })
+				return remove(destPath)
 					.then(function(paths) {
 						return true;
 					});

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,1057 @@
+{
+  "name": "recursive-copy",
+  "version": "2.0.13",
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4"
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4"
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2"
+        },
+        "ansi-styles": {
+          "version": "3.2.1"
+        },
+        "color-convert": {
+          "version": "1.9.3"
+        },
+        "color-name": {
+          "version": "1.1.3"
+        },
+        "has-flag": {
+          "version": "3.0.0"
+        },
+        "supports-color": {
+          "version": "5.5.0"
+        }
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3"
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3"
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4"
+    },
+    "@sindresorhus/is": {
+      "version": "0.14.0"
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2"
+    },
+    "@types/color-name": {
+      "version": "1.1.1"
+    },
+    "@types/minimist": {
+      "version": "1.2.0"
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.0"
+    },
+    "acorn": {
+      "version": "5.7.4"
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0"
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.11.8"
+    },
+    "ajv-keywords": {
+      "version": "1.5.1"
+    },
+    "ansi-align": {
+      "version": "3.0.0",
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0"
+        },
+        "emoji-regex": {
+          "version": "7.0.3"
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0"
+        },
+        "ansi-regex": {
+          "version": "4.1.0"
+        },
+        "strip-ansi": {
+          "version": "5.2.0"
+        }
+      }
+    },
+    "ansi-escapes": {
+      "version": "1.4.0"
+    },
+    "ansi-regex": {
+      "version": "2.1.1"
+    },
+    "ansi-styles": {
+      "version": "2.2.1"
+    },
+    "argparse": {
+      "version": "1.0.10"
+    },
+    "array-differ": {
+      "version": "1.0.0"
+    },
+    "array-union": {
+      "version": "1.0.2"
+    },
+    "array-uniq": {
+      "version": "1.0.3"
+    },
+    "arrify": {
+      "version": "1.0.1"
+    },
+    "asap": {
+      "version": "2.0.6"
+    },
+    "assertion-error": {
+      "version": "1.1.0"
+    },
+    "async": {
+      "version": "0.1.22"
+    },
+    "balanced-match": {
+      "version": "1.0.0"
+    },
+    "boxen": {
+      "version": "4.2.0",
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0"
+        },
+        "ansi-styles": {
+          "version": "4.2.1"
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11"
+    },
+    "braces": {
+      "version": "3.0.2"
+    },
+    "buffer-from": {
+      "version": "1.1.1"
+    },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0"
+        },
+        "lowercase-keys": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "caller-path": {
+      "version": "0.1.0"
+    },
+    "callsites": {
+      "version": "0.2.0"
+    },
+    "camelcase": {
+      "version": "5.3.1"
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "dependencies": {
+        "map-obj": {
+          "version": "4.1.0"
+        }
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "ci-info": {
+      "version": "2.0.0"
+    },
+    "circular-json": {
+      "version": "0.3.3"
+    },
+    "cli-boxes": {
+      "version": "2.2.0"
+    },
+    "cli-cursor": {
+      "version": "1.0.2"
+    },
+    "cli-width": {
+      "version": "2.2.1"
+    },
+    "clone-response": {
+      "version": "1.0.2"
+    },
+    "co": {
+      "version": "4.6.0"
+    },
+    "code-point-at": {
+      "version": "1.1.0"
+    },
+    "color-convert": {
+      "version": "2.0.1"
+    },
+    "color-name": {
+      "version": "1.1.4"
+    },
+    "commander": {
+      "version": "2.3.0"
+    },
+    "concat-map": {
+      "version": "0.0.1"
+    },
+    "concat-stream": {
+      "version": "1.6.2"
+    },
+    "configstore": {
+      "version": "5.0.1"
+    },
+    "core-util-is": {
+      "version": "1.0.2"
+    },
+    "cross-spawn": {
+      "version": "5.1.0"
+    },
+    "crypto-random-string": {
+      "version": "2.0.0"
+    },
+    "d": {
+      "version": "1.0.1"
+    },
+    "debug": {
+      "version": "2.2.0"
+    },
+    "decamelize": {
+      "version": "1.2.0"
+    },
+    "decamelize-keys": {
+      "version": "1.1.0"
+    },
+    "decompress-response": {
+      "version": "3.3.0"
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1"
+        }
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0"
+    },
+    "deep-is": {
+      "version": "0.1.3"
+    },
+    "defer-to-connect": {
+      "version": "1.1.3"
+    },
+    "diff": {
+      "version": "1.4.0"
+    },
+    "dir-glob": {
+      "version": "3.0.1"
+    },
+    "doctrine": {
+      "version": "1.5.0"
+    },
+    "dot-prop": {
+      "version": "5.2.0"
+    },
+    "duplexer3": {
+      "version": "0.1.4"
+    },
+    "emoji-regex": {
+      "version": "8.0.0"
+    },
+    "end-of-stream": {
+      "version": "1.4.4"
+    },
+    "errno": {
+      "version": "0.1.7"
+    },
+    "error-ex": {
+      "version": "1.3.2"
+    },
+    "errs": {
+      "version": "0.1.1"
+    },
+    "es5-ext": {
+      "version": "0.10.53"
+    },
+    "es6-iterator": {
+      "version": "2.0.3"
+    },
+    "es6-map": {
+      "version": "0.1.5"
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.1.1"
+        }
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3"
+    },
+    "es6-weak-map": {
+      "version": "2.0.3"
+    },
+    "escape-goat": {
+      "version": "2.1.1"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5"
+    },
+    "escope": {
+      "version": "3.6.0"
+    },
+    "eslint-formatter-pretty": {
+      "version": "3.0.1",
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.1"
+        },
+        "chalk": {
+          "version": "3.0.0"
+        },
+        "ansi-styles": {
+          "version": "4.2.1"
+        },
+        "type-fest": {
+          "version": "0.11.0"
+        }
+      }
+    },
+    "eslint-rule-docs": {
+      "version": "1.1.205"
+    },
+    "espree": {
+      "version": "3.5.4"
+    },
+    "esprima": {
+      "version": "4.0.1"
+    },
+    "esrecurse": {
+      "version": "4.2.1"
+    },
+    "estraverse": {
+      "version": "4.3.0"
+    },
+    "esutils": {
+      "version": "2.0.3"
+    },
+    "event-emitter": {
+      "version": "0.3.5"
+    },
+    "exit-hook": {
+      "version": "1.1.1"
+    },
+    "ext": {
+      "version": "1.4.0",
+      "dependencies": {
+        "type": {
+          "version": "2.1.0"
+        }
+      }
+    },
+    "fast-glob": {
+      "version": "3.2.4"
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6"
+    },
+    "fastq": {
+      "version": "1.8.0"
+    },
+    "figures": {
+      "version": "1.7.0"
+    },
+    "file-entry-cache": {
+      "version": "1.3.1"
+    },
+    "fill-range": {
+      "version": "7.0.1"
+    },
+    "find-up": {
+      "version": "4.1.0"
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3"
+        }
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0"
+    },
+    "generate-function": {
+      "version": "2.3.1"
+    },
+    "generate-object-property": {
+      "version": "1.2.0"
+    },
+    "get-stream": {
+      "version": "4.1.0"
+    },
+    "glob": {
+      "version": "7.1.6"
+    },
+    "glob-parent": {
+      "version": "5.1.1"
+    },
+    "global-dirs": {
+      "version": "2.0.1"
+    },
+    "globals": {
+      "version": "9.18.0"
+    },
+    "globby": {
+      "version": "11.0.1",
+      "dependencies": {
+        "array-union": {
+          "version": "2.1.0"
+        },
+        "ignore": {
+          "version": "5.1.8"
+        },
+        "slash": {
+          "version": "3.0.0"
+        }
+      }
+    },
+    "got": {
+      "version": "9.6.0"
+    },
+    "graceful-fs": {
+      "version": "4.2.4"
+    },
+    "growl": {
+      "version": "1.9.2"
+    },
+    "hard-rejection": {
+      "version": "2.1.0"
+    },
+    "has-ansi": {
+      "version": "2.0.0"
+    },
+    "has-flag": {
+      "version": "4.0.0"
+    },
+    "has-yarn": {
+      "version": "2.1.0"
+    },
+    "hosted-git-info": {
+      "version": "2.8.8"
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0"
+    },
+    "ignore": {
+      "version": "3.3.10"
+    },
+    "import-lazy": {
+      "version": "2.1.0"
+    },
+    "imurmurhash": {
+      "version": "0.1.4"
+    },
+    "indent-string": {
+      "version": "4.0.0"
+    },
+    "inflight": {
+      "version": "1.0.6"
+    },
+    "inherits": {
+      "version": "2.0.4"
+    },
+    "ini": {
+      "version": "1.3.5"
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2"
+        }
+      }
+    },
+    "irregular-plurals": {
+      "version": "2.0.0"
+    },
+    "is-arrayish": {
+      "version": "0.2.1"
+    },
+    "is-ci": {
+      "version": "2.0.0"
+    },
+    "is-extglob": {
+      "version": "2.1.1"
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0"
+    },
+    "is-glob": {
+      "version": "4.0.1"
+    },
+    "is-installed-globally": {
+      "version": "0.3.2"
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0"
+    },
+    "is-my-json-valid": {
+      "version": "2.20.5"
+    },
+    "is-npm": {
+      "version": "4.0.0"
+    },
+    "is-number": {
+      "version": "7.0.0"
+    },
+    "is-obj": {
+      "version": "2.0.0"
+    },
+    "is-path-inside": {
+      "version": "3.0.2"
+    },
+    "is-plain-obj": {
+      "version": "1.1.0"
+    },
+    "is-property": {
+      "version": "1.0.2"
+    },
+    "is-resolvable": {
+      "version": "1.1.0"
+    },
+    "is-typedarray": {
+      "version": "1.0.0"
+    },
+    "is-yarn-global": {
+      "version": "0.3.0"
+    },
+    "isarray": {
+      "version": "1.0.0"
+    },
+    "isexe": {
+      "version": "2.0.0"
+    },
+    "jade": {
+      "version": "0.26.3",
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1"
+        },
+        "mkdirp": {
+          "version": "0.3.0"
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0"
+    },
+    "js-yaml": {
+      "version": "3.14.0"
+    },
+    "json-buffer": {
+      "version": "3.0.0"
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.0"
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1"
+    },
+    "jsonify": {
+      "version": "0.0.0"
+    },
+    "jsonpointer": {
+      "version": "4.1.0"
+    },
+    "junk": {
+      "version": "1.0.3"
+    },
+    "keyv": {
+      "version": "3.1.0"
+    },
+    "kind-of": {
+      "version": "6.0.3"
+    },
+    "latest-version": {
+      "version": "5.1.0"
+    },
+    "levn": {
+      "version": "0.3.0"
+    },
+    "lines-and-columns": {
+      "version": "1.1.6"
+    },
+    "locate-path": {
+      "version": "5.0.0"
+    },
+    "lodash": {
+      "version": "4.17.20"
+    },
+    "log-symbols": {
+      "version": "3.0.0",
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2"
+        },
+        "ansi-styles": {
+          "version": "3.2.1"
+        },
+        "color-convert": {
+          "version": "1.9.3"
+        },
+        "has-flag": {
+          "version": "3.0.0"
+        },
+        "color-name": {
+          "version": "1.1.3"
+        },
+        "supports-color": {
+          "version": "5.5.0"
+        }
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1"
+    },
+    "lru-cache": {
+      "version": "4.1.5"
+    },
+    "make-dir": {
+      "version": "3.1.0"
+    },
+    "map-obj": {
+      "version": "1.0.1"
+    },
+    "maximatch": {
+      "version": "0.1.0"
+    },
+    "meow": {
+      "version": "7.1.0",
+      "dependencies": {
+        "type-fest": {
+          "version": "0.13.1"
+        }
+      }
+    },
+    "merge2": {
+      "version": "1.4.1"
+    },
+    "micromatch": {
+      "version": "4.0.2"
+    },
+    "mimic-response": {
+      "version": "1.0.1"
+    },
+    "min-indent": {
+      "version": "1.0.1"
+    },
+    "minimatch": {
+      "version": "3.0.4"
+    },
+    "minimist": {
+      "version": "1.2.5"
+    },
+    "minimist-options": {
+      "version": "4.1.0"
+    },
+    "mkdirp": {
+      "version": "0.5.5"
+    },
+    "ms": {
+      "version": "0.7.1"
+    },
+    "mute-stream": {
+      "version": "0.0.5"
+    },
+    "next-tick": {
+      "version": "1.0.0"
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1"
+        }
+      }
+    },
+    "normalize-url": {
+      "version": "4.5.0"
+    },
+    "number-is-nan": {
+      "version": "1.0.1"
+    },
+    "object-assign": {
+      "version": "4.1.1"
+    },
+    "once": {
+      "version": "1.4.0"
+    },
+    "onetime": {
+      "version": "1.1.0"
+    },
+    "optionator": {
+      "version": "0.8.3"
+    },
+    "os-homedir": {
+      "version": "1.0.2"
+    },
+    "p-cancelable": {
+      "version": "1.1.0"
+    },
+    "p-limit": {
+      "version": "2.3.0"
+    },
+    "p-locate": {
+      "version": "4.1.0"
+    },
+    "p-try": {
+      "version": "2.2.0"
+    },
+    "package-json": {
+      "version": "6.5.0"
+    },
+    "parse-json": {
+      "version": "5.1.0"
+    },
+    "path-exists": {
+      "version": "4.0.0"
+    },
+    "path-is-absolute": {
+      "version": "1.0.1"
+    },
+    "path-is-inside": {
+      "version": "1.0.2"
+    },
+    "path-parse": {
+      "version": "1.0.6"
+    },
+    "path-type": {
+      "version": "4.0.0"
+    },
+    "picomatch": {
+      "version": "2.2.2"
+    },
+    "pify": {
+      "version": "2.3.0"
+    },
+    "plur": {
+      "version": "3.1.1"
+    },
+    "pluralize": {
+      "version": "1.2.1"
+    },
+    "prelude-ls": {
+      "version": "1.1.2"
+    },
+    "prepend-http": {
+      "version": "2.0.0"
+    },
+    "process-nextick-args": {
+      "version": "2.0.1"
+    },
+    "progress": {
+      "version": "1.1.8"
+    },
+    "promise": {
+      "version": "7.3.1"
+    },
+    "prr": {
+      "version": "1.0.1"
+    },
+    "pseudomap": {
+      "version": "1.0.2"
+    },
+    "pump": {
+      "version": "3.0.0"
+    },
+    "pupa": {
+      "version": "2.0.1"
+    },
+    "quick-lru": {
+      "version": "4.0.1"
+    },
+    "rc": {
+      "version": "1.2.8",
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1"
+        }
+      }
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "dependencies": {
+        "type-fest": {
+          "version": "0.6.0"
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1"
+    },
+    "readable-stream": {
+      "version": "2.3.7"
+    },
+    "readline2": {
+      "version": "1.0.1"
+    },
+    "redent": {
+      "version": "3.0.0"
+    },
+    "registry-auth-token": {
+      "version": "4.2.0"
+    },
+    "registry-url": {
+      "version": "5.1.0"
+    },
+    "require-uncached": {
+      "version": "1.0.3"
+    },
+    "resolve": {
+      "version": "1.17.0"
+    },
+    "resolve-from": {
+      "version": "1.0.1"
+    },
+    "responselike": {
+      "version": "1.0.2"
+    },
+    "restore-cursor": {
+      "version": "1.0.1"
+    },
+    "reusify": {
+      "version": "1.0.4"
+    },
+    "rimraf": {
+      "version": "2.7.1"
+    },
+    "run-async": {
+      "version": "0.1.0"
+    },
+    "run-parallel": {
+      "version": "1.1.9"
+    },
+    "rx-lite": {
+      "version": "3.1.2"
+    },
+    "safe-buffer": {
+      "version": "5.1.2"
+    },
+    "semver": {
+      "version": "6.3.0"
+    },
+    "semver-diff": {
+      "version": "3.1.1"
+    },
+    "shebang-command": {
+      "version": "1.2.0"
+    },
+    "shebang-regex": {
+      "version": "1.0.0"
+    },
+    "shelljs": {
+      "version": "0.6.1"
+    },
+    "sigmund": {
+      "version": "1.0.1"
+    },
+    "signal-exit": {
+      "version": "3.0.3"
+    },
+    "slash": {
+      "version": "1.0.0"
+    },
+    "slice-ansi": {
+      "version": "0.0.4"
+    },
+    "spdx-correct": {
+      "version": "3.1.1"
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0"
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1"
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5"
+    },
+    "sprintf-js": {
+      "version": "1.0.3"
+    },
+    "string-width": {
+      "version": "4.2.0",
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "3.0.0"
+        },
+        "strip-ansi": {
+          "version": "6.0.0"
+        },
+        "ansi-regex": {
+          "version": "5.0.0"
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1"
+    },
+    "strip-ansi": {
+      "version": "3.0.1"
+    },
+    "strip-indent": {
+      "version": "3.0.0"
+    },
+    "strip-json-comments": {
+      "version": "1.0.4"
+    },
+    "supports-color": {
+      "version": "7.1.0"
+    },
+    "supports-hyperlinks": {
+      "version": "2.1.0"
+    },
+    "table": {
+      "version": "3.8.3",
+      "dependencies": {
+        "string-width": {
+          "version": "2.1.1"
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0"
+        },
+        "ansi-regex": {
+          "version": "3.0.0"
+        },
+        "strip-ansi": {
+          "version": "4.0.0"
+        }
+      }
+    },
+    "term-size": {
+      "version": "2.2.0"
+    },
+    "text-table": {
+      "version": "0.2.0"
+    },
+    "through": {
+      "version": "2.3.8"
+    },
+    "to-iso-string": {
+      "version": "0.0.2"
+    },
+    "to-readable-stream": {
+      "version": "1.0.0"
+    },
+    "to-regex-range": {
+      "version": "5.0.1"
+    },
+    "trim-newlines": {
+      "version": "3.0.0"
+    },
+    "type": {
+      "version": "1.2.0"
+    },
+    "type-check": {
+      "version": "0.3.2"
+    },
+    "type-detect": {
+      "version": "1.0.0"
+    },
+    "type-fest": {
+      "version": "0.8.1"
+    },
+    "typedarray": {
+      "version": "0.0.6"
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5"
+    },
+    "unique-string": {
+      "version": "2.0.0"
+    },
+    "update-notifier": {
+      "version": "4.1.1",
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0"
+        },
+        "ansi-styles": {
+          "version": "4.2.1"
+        }
+      }
+    },
+    "url-parse-lax": {
+      "version": "3.0.0"
+    },
+    "user-home": {
+      "version": "2.0.0"
+    },
+    "util-deprecate": {
+      "version": "1.0.2"
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4"
+    },
+    "which": {
+      "version": "1.3.1"
+    },
+    "widest-line": {
+      "version": "3.1.0"
+    },
+    "word-wrap": {
+      "version": "1.2.3"
+    },
+    "wrappy": {
+      "version": "1.0.2"
+    },
+    "write": {
+      "version": "0.2.1"
+    },
+    "write-file-atomic": {
+      "version": "3.0.3"
+    },
+    "xdg-basedir": {
+      "version": "4.0.0"
+    },
+    "xtend": {
+      "version": "4.0.2"
+    },
+    "yallist": {
+      "version": "2.1.2"
+    },
+    "yargs-parser": {
+      "version": "18.1.3"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "test": "npm run test:lint && npm run test:mocha && if-node-version '>=10' npm run test:typings",
-    "test:lint": "eslint index.js test",
+    "test:lint": "if-node-version '>=4' eslint index.js test",
     "test:mocha": "mocha --reporter spec",
     "test:typings": "tsd && echo 'TypeScript definitions are valid'",
     "prepublishOnly": "npm run test"
@@ -60,7 +60,6 @@
     "@types/node": "^14.6.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
-    "del": "^2.2.0",
     "eslint": "^2.9.0",
     "if-node-version": "^1.1.1",
     "mocha": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "homepage": "https://github.com/timkendrick/recursive-copy",
   "dependencies": {
-    "del": "^2.2.0",
     "errno": "^0.1.2",
     "graceful-fs": "^4.1.4",
     "junk": "^1.0.1",
@@ -54,12 +53,14 @@
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",
     "promise": "^7.0.1",
+    "rimraf": "^2.7.1",
     "slash": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^14.6.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
+    "del": "^2.2.0",
     "eslint": "^2.9.0",
     "if-node-version": "^1.1.1",
     "mocha": "^2.4.5",

--- a/test/spec/copy.spec.js
+++ b/test/spec/copy.spec.js
@@ -7,7 +7,7 @@ var path = require('path');
 var chai = require('chai');
 var expect = chai.expect;
 var chaiAsPromised = require('chai-as-promised');
-var del = require('del');
+var rimraf = require('rimraf');
 var slash = require('slash');
 var readDirFiles = require('read-dir-files');
 var through = require('through2');
@@ -28,21 +28,15 @@ describe('copy()', function() {
 	beforeEach(function(done) {
 		fs.mkdir(DESTINATION_PATH, function(error) {
 			if (error) {
-				del(path.join(DESTINATION_PATH, '**/*'), {
-					dot: true,
-					force: true
-				}, done);
+				rimraf(path.join(DESTINATION_PATH, '**/*'), done);
 			} else {
 				done();
 			}
 		});
 	});
 
-	afterEach(function() {
-		return del(DESTINATION_PATH, {
-			dot: true,
-			force: true
-		});
+	afterEach(function(done) {
+		return rimraf(DESTINATION_PATH, done);
 	});
 
 	function getSourcePath(filename) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,19 +522,6 @@ defer-to-connect@^1.0.1:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
 
-del@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
-  integrity sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=
-  dependencies:
-    globby "^5.0.0"
-    is-path-cwd "^1.0.0"
-    is-path-in-cwd "^1.0.0"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    rimraf "^2.2.8"
-
 diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
@@ -951,18 +938,6 @@ globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
-  integrity sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=
-  dependencies:
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -1181,25 +1156,6 @@ is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
-
-is-path-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
-  integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
-
-is-path-in-cwd@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
-  integrity sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
-  dependencies:
-    is-path-inside "^1.0.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
-  dependencies:
-    path-is-inside "^1.0.1"
 
 is-path-inside@^3.0.1:
   version "3.0.2"
@@ -1652,22 +1608,10 @@ picomatch@^2.0.5, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
-pify@^2.0.0, pify@^2.3.0:
+pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
-
-pinkie-promise@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
-  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
-  dependencies:
-    pinkie "^2.0.0"
-
-pinkie@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
 plur@^3.0.1:
   version "3.1.1"
@@ -1864,7 +1808,7 @@ rewire@^2.3.3:
   resolved "https://registry.yarnpkg.com/rewire/-/rewire-2.5.2.tgz#6427de7b7feefa7d36401507eb64a5385bc58dc7"
   integrity sha1-ZCfee3/u+n02QBUH62SlOFvFjcc=
 
-rimraf@^2.2.8, rimraf@^2.7.1:
+rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1864,7 +1864,7 @@ rewire@^2.3.3:
   resolved "https://registry.yarnpkg.com/rewire/-/rewire-2.5.2.tgz#6427de7b7feefa7d36401507eb64a5385bc58dc7"
   integrity sha1-ZCfee3/u+n02QBUH62SlOFvFjcc=
 
-rimraf@^2.2.8:
+rimraf@^2.2.8, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==


### PR DESCRIPTION
Running yarn install after replacing `del` with `rimraf` removes 7 transitive dependencies:
- globby@5.0.0
- pinkie-promise@2.0.1
- pinkie@2.0.4
- is-path-cwd@1.0.0
- is-path-in-cwd@1.0.1
- is-path-inside@1.0.1
- path-is-inside@1.0.2

node_modules size decreases from from 1.2M to 996K

`del` uses `rimraf` under the hood. It adds a Promise api
and different glob handling.
Outside of tests, recursive-copy calls `del` once, to delete a file that's
already been passed to `lstat`.
recursive-copy already uses pify to promisify APIs and performs
its own glob handling. It also uses `del` with the `force` option
set, which bypasses extra safety checks that `del` introduces. Therefore
there should be no downside to calling `rimraf` directly.