### PR TITLE
resolve promise when the copied file is closed

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -335,7 +335,7 @@ function copyFile(srcPath, destPath, stats, options) {
 			mode: stats.mode
 		});
 		write.on('error', handleCopyFailed);
-		write.on('finish', function() {
+		write.on('close', function() {
 			fs.utimes(destPath, stats.atime, stats.mtime, function() {
 				hasFinished = true;
 				resolve();


### PR DESCRIPTION
Copied file handlers are not fully closed when returning results

https://github.com/timkendrick/recursive-copy/issues/38